### PR TITLE
Fix cypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ See the section about [running tests](https://facebook.github.io/create-react-ap
 
 Launches the integration test runner from [Cypress](https://docs.cypress.io/guides/getting-started/testing-your-app.html#Step-1-Start-your-server). See `yarn cypress` for other commands.
 
+Remember that it expects you to start the development server (`yarn start`) separately, as it will use it to run the tests.
+
 ### `yarn build`
 
 Builds the app for production to the `build` folder.<br />

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     ]
   },
   "devDependencies": {
+    "@cypress/webpack-preprocessor": "^5.4.1",
     "cypress": "^4.6.0"
   }
 }


### PR DESCRIPTION
Our Cypress setup appears to have some hidden dependencies. This is what I get when I run it on the console:

```
$ yarn cypress run
The plugins file is missing or invalid.

Your `pluginsFile` is set to `/home/pablobm/Documents/projects/wittrcoin-web/cypress/plugins/index.js`, but either the file is missing, it contains a syntax error, or threw an error when required. The `pluginsFile` must be a `.js` or `.coffee` file.

Or you might have renamed the extension of your `pluginsFile` to `.ts`. If that's the case, restart the test runner.

Please fix this, or set `pluginsFile` to `false` if a plugins file is not necessary for your project.

 Error: Cannot find module '@cypress/webpack-preprocessor'
Require stack:
- /home/pablobm/Documents/projects/wittrcoin-web/cypress/plugins/index.js
- /home/pablobm/.cache/Cypress/4.6.0/Cypress/resources/app/packages/server/lib/plugins/child/run_plugins.js
- /home/pablobm/.cache/Cypress/4.6.0/Cypress/resources/app/packages/server/lib/plugins/child/index.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:798:15)
    at Module._load (internal/modules/cjs/loader.js:691:27)
    at Module._load (electron/js2c/asar.js:717:26)
    at Function.Module._load (electron/js2c/asar.js:717:26)
    at Module.require (internal/modules/cjs/loader.js:853:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/home/pablobm/Documents/projects/wittrcoin-web/cypress/plugins/index.js:15:29)
    at Module._compile (internal/modules/cjs/loader.js:968:30)
    at Module.m._compile (/home/pablobm/.cache/Cypress/4.6.0/Cypress/resources/app/packages/server/node_modules/ts-node/src/index.ts:536:23)
    at Module._extensions..js (internal/modules/cjs/loader.js:986:10)
    at Object.require.extensions.<computed> [as .js] (/home/pablobm/.cache/Cypress/4.6.0/Cypress/resources/app/packages/server/node_modules/ts-node/src/index.ts:539:12)
    at Module.load (internal/modules/cjs/loader.js:816:32)
    at Module._load (internal/modules/cjs/loader.js:728:14)
    at Module._load (electron/js2c/asar.js:717:26)
    at Function.Module._load (electron/js2c/asar.js:717:26)
    at Module.require (internal/modules/cjs/loader.js:853:19)
```

Similar if I run it with with `yarn cypress open`:

![Similar failure, but on a browser window](https://user-images.githubusercontent.com/36066/83320741-35a88800-a242-11ea-802b-d55564d761ec.png)

Installing the missing dependency fixed the issue. It probably works for @benfurber because he has this package installed globally. Adding it to `package.json` should make it work for everyone.

Additionally, added some more info on how to run the tests to the README.
